### PR TITLE
added plain css loader

### DIFF
--- a/webpack/shared.js
+++ b/webpack/shared.js
@@ -15,6 +15,10 @@ module.exports = {
       test: /\.styl$/,
       loader: 'style!css!autoprefixer!stylus',
       include: path.resolve(__dirname, '../src')
+    }, {
+      id: 'css',
+      test: /\.css$/,
+      loader: 'style!css',
     }]
   }
 };

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -19,7 +19,7 @@ module.exports = {
   },
   module: Object.assign({}, shared.module, {
     loaders: shared.module.loaders.map((loader) => {
-      if (loader.id === 'style') {
+      if (loader.id === 'style' || loader.id === 'css') {
         return Object.assign({}, loader, {
           loader: ExtractTextPlugin.extract('style', loader.loader.replace('style', ''))
         });


### PR DESCRIPTION
Third party libraries usually use plain css. Added plain CSS loader to be able import .css from node_modules (eg stylesheet for react-data-table)